### PR TITLE
fix: resolve white background issue in use case radar chart

### DIFF
--- a/src/components/charts/RadarChart.tsx
+++ b/src/components/charts/RadarChart.tsx
@@ -29,9 +29,9 @@ const RadarChartComponent: React.FC<RadarChartComponentProps> = ({ className = '
   };
 
   return (
-    <div className={`card p-6 ${className}`}>
-      <h3 className="text-lg font-semibold mb-4">Comparação por Radar</h3>
-      <div className="h-96">
+    <div className={`${className}`}>
+      <h3 className="text-xl font-bold mb-4 gradient-text">Comparação por Radar</h3>
+      <div className="h-80">
         <ResponsiveContainer width="100%" height="100%">
           <RadarChart data={data}>
             <PolarGrid className="opacity-30" />
@@ -88,22 +88,22 @@ const RadarChartComponent: React.FC<RadarChartComponentProps> = ({ className = '
               dataKey="LangChain"
               stroke="rgb(59 130 246)"
               fill="rgb(59 130 246)"
-              fillOpacity={0.1}
+              fillOpacity={0.2}
               strokeWidth={2}
             />
             <Radar
               name="Agno"
               dataKey="Agno"
-              stroke="rgb(16 185 129)"
-              fill="rgb(16 185 129)"
-              fillOpacity={0.1}
+              stroke="rgb(34 197 94)"
+              fill="rgb(34 197 94)"
+              fillOpacity={0.2}
               strokeWidth={2}
             />
             <Legend />
           </RadarChart>
         </ResponsiveContainer>
       </div>
-      <p className="text-sm text-muted-foreground mt-2">
+      <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
         Escala de 0-10 pontos por critério. Dados fictícios para demonstração.
       </p>
     </div>

--- a/src/components/charts/UseCaseRadarChart.tsx
+++ b/src/components/charts/UseCaseRadarChart.tsx
@@ -27,6 +27,23 @@ interface UseCaseRadarChartProps {
   };
 }
 
+interface RadarDataPoint {
+  subject: string;
+  [key: string]: string | number;
+}
+
+interface TooltipPayload {
+  dataKey: string;
+  value: number;
+  color: string;
+}
+
+interface CustomTooltipProps {
+  active?: boolean;
+  payload?: TooltipPayload[];
+  label?: string;
+}
+
 const UseCaseRadarChart: React.FC<UseCaseRadarChartProps> = ({ data }) => {
   // Dados padrão caso não sejam fornecidos
   const defaultData = {
@@ -60,20 +77,20 @@ const UseCaseRadarChart: React.FC<UseCaseRadarChartProps> = ({ data }) => {
   const chartData = data || defaultData;
 
   // Converter dados para formato do recharts
-  const radarData = chartData.labels.map((label, index) => {
-    const dataPoint: any = { subject: label };
+  const radarData: RadarDataPoint[] = chartData.labels.map((label, index) => {
+    const dataPoint: RadarDataPoint = { subject: label };
     chartData.datasets.forEach(dataset => {
       dataPoint[dataset.label] = dataset.data[index];
     });
     return dataPoint;
   });
 
-  const CustomTooltip = ({ active, payload, label }: any) => {
+  const CustomTooltip: React.FC<CustomTooltipProps> = ({ active, payload, label }) => {
     if (active && payload && payload.length) {
       return (
         <div className="bg-white dark:bg-gray-800 p-3 border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg">
-          <p className="font-semibold text-gray-900 dark:text-gray-100">{`${label}`}</p>
-          {payload.map((entry: any, index: number) => (
+          <p className="font-semibold text-gray-900 dark:text-gray-100">{label}</p>
+          {payload.map((entry, index) => (
             <p key={index} style={{ color: entry.color }} className="text-sm">
               {`${entry.dataKey}: ${entry.value}%`}
             </p>
@@ -85,27 +102,38 @@ const UseCaseRadarChart: React.FC<UseCaseRadarChartProps> = ({ data }) => {
   };
 
   return (
-    <div className="w-full h-96">
+    <div className="w-full h-96 bg-white dark:bg-gray-900 rounded-lg p-4">
       <h3 className="text-lg font-semibold mb-4 text-center text-gray-900 dark:text-gray-100">
         Adequação por Categoria de Uso
       </h3>
       <ResponsiveContainer width="100%" height="100%">
         <RadarChart data={radarData} margin={{ top: 20, right: 30, bottom: 20, left: 30 }}>
-          <PolarGrid className="stroke-gray-300 dark:stroke-gray-600" />
-          <PolarAngleAxis 
+          <PolarGrid className="stroke-gray-300 dark:stroke-gray-600 opacity-30" />
+          <PolarAngleAxis
             dataKey="subject" 
-            className="text-xs fill-gray-700 dark:fill-gray-300"
-            tick={{ fontSize: 12 }}
+            className="text-xs"
+            tick={{
+              fontSize: 12,
+              fill: 'currentColor',
+              textAnchor: 'middle',
+              dominantBaseline: 'middle'
+            }}
           />
           <PolarRadiusAxis 
             angle={90} 
             domain={[0, 100]} 
-            className="text-xs fill-gray-500 dark:fill-gray-400"
-            tick={{ fontSize: 10 }}
+            className="text-xs"
+            tick={{
+              fontSize: 10,
+              fill: 'currentColor'
+            }}
           />
           <Tooltip content={<CustomTooltip />} />
           <Legend 
-            wrapperStyle={{ paddingTop: '20px' }}
+            wrapperStyle={{
+              paddingTop: '20px',
+              color: 'currentColor'
+            }}
             iconType="circle"
           />
           {chartData.datasets.map((dataset, index) => (

--- a/src/index.css
+++ b/src/index.css
@@ -570,3 +570,45 @@
     display: none !important;
   }
 }
+
+/* Garantir que os gráficos Recharts tenham a mesma cor de fundo da classe card */
+.recharts-wrapper,
+.recharts-surface {
+  background: rgba(255, 255, 255, 0.98) !important;
+}
+
+.recharts-wrapper svg,
+.recharts-surface svg {
+  background: rgba(255, 255, 255, 0.98) !important;
+}
+
+.card .recharts-wrapper,
+.card .recharts-surface {
+  background: rgba(255, 255, 255, 0.98) !important;
+}
+
+.card .recharts-wrapper svg,
+.card .recharts-surface svg {
+  background: rgba(255, 255, 255, 0.98) !important;
+}
+
+/* Tema escuro */
+.dark .recharts-wrapper,
+.dark .recharts-surface {
+  background: rgba(15, 23, 42, 0.98) !important;
+}
+
+.dark .recharts-wrapper svg,
+.dark .recharts-surface svg {
+  background: rgba(15, 23, 42, 0.98) !important;
+}
+
+.dark .card .recharts-wrapper,
+.dark .card .recharts-surface {
+  background: rgba(15, 23, 42, 0.98) !important;
+}
+
+.dark .card .recharts-wrapper svg,
+.dark .card .recharts-surface svg {
+  background: rgba(15, 23, 42, 0.98) !important;
+}

--- a/src/routes/comparison/FeaturesPage.tsx
+++ b/src/routes/comparison/FeaturesPage.tsx
@@ -169,10 +169,14 @@ const FeaturesPage: React.FC = () => {
         {/* Charts Section */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           <div className="card-hover">
-            <RadarChartComponent />
+            <div className="card p-6">
+              <RadarChartComponent />
+            </div>
           </div>
           <div className="card-hover">
-            <BarChartComponent />
+            <div className="card p-6">
+              <BarChartComponent />
+            </div>
           </div>
         </div>
 


### PR DESCRIPTION
- Add proper background styling (bg-white dark:bg-gray-900)
- Fix TypeScript issues by removing 'any' types
- Add proper interfaces for radar data and tooltip props
- Standardize styling to match other radar charts
- Improve grid opacity and text styling consistency